### PR TITLE
Add dc_block

### DIFF
--- a/src/dsp/filters.nim
+++ b/src/dsp/filters.nim
@@ -89,3 +89,15 @@ proc iir*[NX, NY: static[Natural]](x: float, a: array[NY, float], b: array[NX,
   for i in countdown(NX+NY-1, NX+1):
     s[i] = s[i-1]
   s[NX] = result
+
+type
+  DC_Block* = object
+    xm: float
+    ym: float
+
+proc dc_block*(x: float, s: var DC_Block): float =
+  # https://ccrma.stanford.edu/~jos/filters/DC_Blocker_Software_Implementations.html
+  result = x - s.xm + 0.995 * s.ym;
+  s.ym = result
+  s.xm = x
+lift1(dc_block, DC_Block)

--- a/src/pool.nim
+++ b/src/pool.nim
@@ -27,6 +27,7 @@ type
     clock: array[medium_pool, Clock]
     compressor: array[medium_pool, Compressor]
     conv: array[medium_pool, Conv]
+    dc_block: array[small_pool, DC_Block]
     delay: array[medium_pool, Delay1]
     diode: array[medium_pool, Diode]
     hpf: array[medium_pool, HPF]
@@ -65,6 +66,7 @@ type
       clock,
       compressor,
       conv,
+      dc_block,
       delay,
       diode,
       hpf,
@@ -144,6 +146,7 @@ def0(brown, brown_noise)
 def0(pink_noise)
 def1(blsaw)
 def1(bltriangle)
+def1(dc_block)
 def1(dmetro, metro)
 def1(jcrev)
 def1(osc, sample)


### PR DESCRIPTION
Implemented dc_bloc as in https://ccrma.stanford.edu/~jos/filters/DC_Blocker_Software_Implementations.html with fixed R parameter.

Researched a little, and on premodelling (just drawings) I can see the difference between the different R, but when it comes to livecore and sound, it seems that the changes are not significant

But nevertheless, I attach the pdf, just to see (for nerdy fun lovers). Green is random input (same on all slides), black is output with current R, numbers on the axis are samples.

[dc_blocker.pdf](https://github.com/ul/livecore/files/7850748/dc_blocker.pdf)
